### PR TITLE
Update to work with Python 3. Pass kwargs to urlopen. Fix imports. Fix tests.

### DIFF
--- a/ogp/__init__.py
+++ b/ogp/__init__.py
@@ -1,1 +1,3 @@
-from opengraph import OpenGraph
+from .opengraph import OpenGraph
+
+__all__ = ("OpenGraph",)

--- a/ogp/opengraph.py
+++ b/ogp/opengraph.py
@@ -1,91 +1,96 @@
 # encoding: utf-8
 
 import re
-import urllib2
-from BeautifulSoup import BeautifulSoup
 from contextlib import closing
-from urlparse import urljoin
+from urllib.parse import urljoin
+from urllib.request import urlopen
 
-class OpenGraph(object):
-    """
-    """
+from bs4 import BeautifulSoup
 
-    
+
+class OpenGraph:
     scrape = False
 
-    def __init__(self, url="http://example.com", html=None, scrape=False, required_attrs = set(('title', 'type', 'image', 'url')), **kwargs):
+    def __init__(
+        self,
+        url="http://example.com",
+        html=None,
+        scrape=False,
+        required_attrs=set(("title", "type", "image", "url")),
+        **kwargs,
+    ):
         # If scrape == True, then will try to fetch missing attribtues
         # from the page's body
         self.scrape = scrape
         self.url = url
         self.items = {}
         self.required_attrs = set(required_attrs)
-            
+
         if not html:
-            with closing(urllib2.urlopen(url)) as raw:
+            with closing(urlopen(url, **kwargs)) as raw:
                 html = raw.read()
-        
+
         self.parser(html)
-    
+
     def absolute(self, url):
         return urljoin(self.url, url)
-    
+
     def parser(self, html):
-        """
-        """
-        if not isinstance(html,BeautifulSoup):
-            doc = BeautifulSoup(html)
+        if not isinstance(html, BeautifulSoup):
+            doc = BeautifulSoup(html, features="html.parser")
         else:
             doc = html
-        ogs = doc.html.head.findAll(property=re.compile(r'^og'))
+        ogs = doc.html.head.findAll(property=re.compile(r"^og"))
         for og in ogs:
-            if og.has_key(u'content'):
-                self.items[og[u'property'][3:]]=og[u'content']
-        
+            if og.has_attr("content"):
+                self.items[og["property"][3:]] = og["content"]
+
         # Couldn't fetch all attrs from og tags, try scraping body
         if self.scrape:
-            remaining_keys = self.required_attrs - set(self.items.viewkeys())
+            remaining_keys = self.required_attrs - set(self.items.keys())
             for key in remaining_keys:
-                self.items[key] = getattr(self, 'scrape_{key}'.format(key=key))(doc)
-        
+                self.items[key] = getattr(self, "scrape_{key}".format(key=key))(doc)
+
         image = self.items.get("image", False)
         if image:
             self.items["image"] = self.absolute(self.items["image"])
-        
+
     def is_valid(self):
-        return self.required_attrs <= set(self.items.viewkeys())
-        
+        return self.required_attrs <= set(self.items.keys())
+
     def to_html(self):
         if not self.is_valid():
-            return u"<meta property=\"og:error\" content=\"og metadata is not valid\" />"
-            
-        meta = u""
-        for key,value in self.items.iteritems():
-            meta += u"\n<meta property=\"og:%s\" content=\"%s\" />" %(key, value)
-        meta += u"\n"
-        
+            return '<meta property="og:error" content="og metadata is not valid" />'
+
+        meta = ""
+        for key, value in self.items.items():
+            meta += '\n<meta property="og:%s" content="%s" />' % (key, value)
+        meta += "\n"
+
         return meta
-        
+
     def scrape_image(self, doc):
-        images = [dict(img.attrs)['src'] 
-            for img in doc.html.body.findAll('img')]
+        images = [dict(img.attrs)["src"] for img in doc.html.body.findAll("img")]
 
         if images:
             return images[0]
 
-        return u''
+        return ""
 
     def scrape_title(self, doc):
         return doc.html.head.title.text
 
     def scrape_type(self, doc):
-        return 'other'
+        return "other"
 
     def scrape_url(self, doc):
         return self.url
-    
+
     def scrape_description(self, doc):
-        ogs = doc.html.head.findAll(name='meta', attrs={"name":("description", "DC.description", "eprints.abstract")}, )
+        ogs = doc.html.head.findAll(
+            name="meta",
+            attrs={"name": ("description", "DC.description", "eprints.abstract")},
+        )
         for og in ogs:
             content = og.get("content", False)
             if content:
@@ -96,4 +101,3 @@ class OpenGraph(object):
                 return heading.text
             else:
                 return doc.html.find("p").text
-        

--- a/ogp/test.py
+++ b/ogp/test.py
@@ -1,8 +1,8 @@
 # encoding: utf-8
 
 import unittest
-import opengraph
 
+from . import OpenGraph
 
 HTML = """
 <html xmlns:og="http://ogp.me/ns#">
@@ -16,44 +16,58 @@ HTML = """
 </html>
 """
 
+
 class test(unittest.TestCase):
     def test_url(self):
-        data = opengraph.OpenGraph(url='http://vimeo.com/896837')
-        self.assertEqual(data.items['url'], 'http://vimeo.com/896837')
-        
+        data = OpenGraph(url="https://vimeo.com/896837")
+        self.assertEqual(data.items["url"], "https://vimeo.com/896837")
+
     def test_isinstace(self):
-        data = opengraph.OpenGraph()
-        self.assertTrue(isinstance(data,opengraph.OpenGraph))
-        
+        data = OpenGraph()
+        self.assertTrue(isinstance(data, OpenGraph))
+
     def test_to_html(self):
-        og = opengraph.OpenGraph(html=HTML)
+        og = OpenGraph(html=HTML)
         self.assertTrue(og.to_html())
-        
+
     def test_is_valid(self):
-        og = opengraph.OpenGraph(url='http://grooveshark.com')
+        og = OpenGraph(url="http://github.com")
         self.assertTrue(og.is_valid())
 
     def test_is_not_valid(self):
-        og = opengraph.OpenGraph(url='http://vdubmexico.com')
+        og = OpenGraph(url="http://itcorp.com/")
         self.assertFalse(og.is_valid())
-    
+
     def test_required(self):
-        og = opengraph.OpenGraph(url='http://grooveshark.com', required_attrs=("description",), scrape=True)
+        og = OpenGraph(
+            url="http://example.com", required_attrs=("description",), scrape=True
+        )
         self.assertTrue(og.is_valid())
-    
+
     def test_scrape(self):
-        og = opengraph.OpenGraph(url='http://graingert.co.uk/', required_attrs=("description",), scrape=True)
+        og = OpenGraph(
+            url="http://graingert.co.uk/", required_attrs=("description",), scrape=True
+        )
         self.assertTrue(og.is_valid())
         self.assertTrue(og.items["description"])
-        
-        og = opengraph.OpenGraph(url='http://www.crummy.com/software/BeautifulSoup/bs3/documentation.html', required_attrs=("description",), scrape=True)
+
+        og = OpenGraph(
+            url="http://www.crummy.com/software/BeautifulSoup/bs3/documentation.html",
+            required_attrs=("description",),
+            scrape=True,
+        )
         self.assertEqual(og.items["description"], "Beautiful Soup Documentation")
 
-    
     def test_absolute(self):
-        og = opengraph.OpenGraph(url='http://www.crummy.com/software/BeautifulSoup/bs3/documentation.html', required_attrs=("image",), scrape=True)
-        self.assertEqual(og.items["image"], "http://www.crummy.com/software/BeautifulSoup/bs3/6.1.jpg")
+        og = OpenGraph(
+            url="http://www.crummy.com/software/BeautifulSoup/bs3/documentation.html",
+            required_attrs=("image",),
+            scrape=True,
+        )
+        self.assertEqual(
+            og.items["image"], "http://www.crummy.com/software/BeautifulSoup/bs3/6.1.jpg"
+        )
 
-    
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -2,33 +2,34 @@ from os.path import join, dirname
 from distutils.core import setup
 
 try:
-    f = open(join(dirname(__file__), 'README.rst'))
+    f = open(join(dirname(__file__), "README.rst"))
     long_description = f.read().strip()
     f.close()
 except IOError:
     long_description = ""
 
 
-version = '0.9.1'
+version = "0.9.1"
 
 setup(
-    name='ogp',
+    name="ogp",
     version=version,
     description="A module to parse the Open Graph Protocol",
     long_description=long_description + "\n",
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'Programming Language :: Python',
-        'Topic :: Text Processing :: Markup :: HTML',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-    ], # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
-    keywords='opengraph protocol facebook',
-    author='Erik Rivera',
-    author_email='erik.river@gmail.com',
-    url='https://github.com/graingert/opengraph',
-    license='MIT',
-    packages=["ogp",],
-    install_requires=['BeautifulSoup'],
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Programming Language :: Python",
+        "Topic :: Text Processing :: Markup :: HTML",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    keywords="opengraph protocol facebook",
+    author="Erik Rivera",
+    author_email="erik.river@gmail.com",
+    url="https://github.com/graingert/opengraph",
+    license="MIT",
+    packages=[
+        "ogp",
+    ],
+    install_requires=["beautifulsoup4"],
 )
-    


### PR DESCRIPTION
A few updates here to make this more useful to modern projects.

- Update to work with Python 3 (discarding Python 2 support)
- Replace urllib2 with Python 3 urllib
- Fix imports to enable `from ogp import OpenGraph` (this wasn't necessarily broken but it's more up to date now)
- Update BeautifulSoup to version 4
- Pass constructor kwargs to `urlopen()` to allow for setting timeouts etc.
- Replace broken URLs in tests with working ones
- Format code with black (just because I have it turned on, really)

If merged, this will constitute a major version bump.